### PR TITLE
Add better error handling. Fixes #8

### DIFF
--- a/cmd/ssh-sign/main.go
+++ b/cmd/ssh-sign/main.go
@@ -33,6 +33,10 @@ func main() {
 	*/
 
 	args := os.Args
+	if len(args) == 1 {
+		fmt.Println("This program is not intended to be run directly. It is called by git when signing commits.")
+		os.Exit(1)
+	}
 	commitToSign := args[len(args)-1]
 	sshUID := args[len(args)-2]
 


### PR DESCRIPTION
Shows a more context-specific error message if the program is run by the user and not by git.

Fixes #8 
