### PR TITLE
Fix GPG signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          fingerprint: ${{ secrets.GPG_FINGERPRINT }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Specify GPG fingerprint to override master fingerprint, as a subkey is being used to sign.