### PR TITLE
Add .goreleaser.yaml for custom building/signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: macos-latest
     environment: release
     steps:
+      - name: Exit if tag not on main branch
+        if: endsWith(github.ref, 'main') == false
+        run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install gon
         run: |
-          go get -u github.com/mitchellh/gox
+          go get -u github.com/mitchellh/gon
           go build -o /gon/gon
           echo "$(pwd)/gon/ >> $GITHUB_PATH"
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: release
     steps:
       - name: Checkout
@@ -22,6 +22,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
+
+      - name: Install gon
+        run: |
+          go get -u github.com/mitchellh/gox
+          go build -o /gon/gon
+          echo "$(pwd)/gon/ >> $GITHUB_PATH"
           
       - name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,26 @@
+signs:
+  - artifacts: binary
+    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
+
+builds:
+- binary: ssh-sign
+  id: git-ssh-sign
+  main: ./cmd/ssh-sign/main.go
+  goos:
+  - linux
+  - windows
+  goarch:
+  - amd64
+  - arm64
+
+# Separated build for the MacOS binary for notarization
+- binary: ssh-sign
+  id: git-ssh-sign-macos
+  main: ./cmd/ssh-sign/main.go
+  goos:
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+  hooks:
+    post: gon gon.hcl

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ signs:
     args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 builds:
-- binary: ssh-sign
+- binary: git-ssh-sign
   id: git-ssh-sign
   main: ./cmd/ssh-sign/main.go
   goos:
@@ -14,7 +14,7 @@ builds:
   - arm64
 
 # Separated build for the MacOS binary for notarization
-- binary: ssh-sign
+- binary: git-ssh-sign
   id: git-ssh-sign-macos
   main: ./cmd/ssh-sign/main.go
   goos:

--- a/gon.hcl
+++ b/gon.hcl
@@ -9,5 +9,5 @@ apple_id {
 }
 
 sign {
-  application_identity = "$@env:AC_APPID"
+  application_identity = "@env:AC_APPID"
 }

--- a/gon.hcl
+++ b/gon.hcl
@@ -1,0 +1,13 @@
+# The path follows a pattern
+# ./dist/BUILD-ID_TARGET/BINARY-NAME
+source = ["./dist/git-ssh-sign-macos/git-ssh-sign"]
+bundle_id = "github.com/Keeper-Security/git-ssh-sign/"
+
+apple_id {
+  username = "@env:AC_USERNAME"
+  password = "@env:AC_PASSWORD"
+}
+
+sign {
+  application_identity = "$@env:AC_APPID"
+}

--- a/gon.hcl
+++ b/gon.hcl
@@ -4,8 +4,8 @@ source = ["./dist/git-ssh-sign-macos/git-ssh-sign"]
 bundle_id = "github.com/Keeper-Security/git-ssh-sign/"
 
 apple_id {
-  username = "@env:AC_USERNAME"
-  password = "@env:AC_PASSWORD"
+  username = "@env:secrets.AC_USERNAME"
+  password = "@env:secrets.AC_PASSWORD"
 }
 
 sign {


### PR DESCRIPTION
A `.goreleaser.yaml` file is need to customize the build process for binary signing and notarization. 

In addition to this, a `gon.hcl` file is needed to complete the notarization of MacOS binaries. 