### PR TITLE
Add local verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ To sign commits automatically, i.e., without the `-S` run:
 git config commit.gpgsign true
 ```
 
+### Local verification
+
+To verify signatures locally with a command such as `git log --show-signature -1`, you must create an `allowed_signers` file with trusted SSH public keys. Typically this file is saved either globally at `.ssh/allowed_signers` or in the local repo at `.git/allowed_signers`. The path to this file needs then to be added to your `.gitconfig` or `.git/config` file. 
+
+```shell
+git config gpg.ssh.allowedSignersFile path/to/file
+```
+
+Each line of your `allowed_signers` file should be a prinicipal of an authorized signing key. The line should start with the email address associated with the public key, seperated by a space.
+
+```text
+test@example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEQvSrBv28KLAjYO7pD91prhlenrm3hZ4B7DdcB/4/H+
+```
+
+> The format of the allowed signers file is documented in full [here](https://www.man7.org/linux/man-pages/man1/ssh-keygen.1.html#:~:text=key%20was%20revoked.-,ALLOWED%20SIGNERS,-top). 
+
+While it is correct syntax to have more than one email address associate with a single public key, it is not recommend or currently supported.
+
 ## Troubleshooting
 
 Git will execute `path/to/ssh-sign -Y sign -Y sign -n git -f SSH-Key-UID some-input.txt`.

--- a/cmd/ssh-sign/main.go
+++ b/cmd/ssh-sign/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	if len(os.Args) == 0 {
-		fmt.Println("FIXME: Usage")
+		fmt.Println("This binary is called by git to sign and verify commits with SSH Keys. It is not intended to be ran directly. To setup and use this tool, please refer to the following documentation: https://docs.keeper.io/secrets-manager/secrets-manager/integrations/git-sign-commits-with-ssh")
 		os.Exit(1)
 	}
 

--- a/cmd/ssh-sign/main.go
+++ b/cmd/ssh-sign/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/Keeper-Security/git-ssh-sign/internal/sign"
 	"github.com/Keeper-Security/git-ssh-sign/internal/vault"
@@ -109,6 +110,9 @@ func main() {
 	} else if action == "find-principals" {
 		// -Y find-principals -f <allowed_signers> -s C:\Users\RICKYW~1\AppData\Local\Temp/.git_vtag_tmpudh6g6 -Overify-time=20230920083515
 		// Get all principals from the allowed_signers file and take compare them the the public key in the signature file.
+		
+		os.WriteFile("find-principals.txt", []byte(strings.Join(os.Args, "\n")), 0644)
+
 
 		allowedSignersFile, err := os.Open(inputFile)
 		if err != nil {
@@ -150,7 +154,7 @@ func main() {
 		// Successful verification by an authorized signer is signalled by
 		// ssh-keygen returning a zero exit status.
 
-		// fmt.Println(os.Args)
+		os.WriteFile("verify.txt", []byte(strings.Join(os.Args, "\n")), 0644)
 
 		sig, err := signatureFileToObj(signatureFile)
 		if err != nil {
@@ -190,11 +194,23 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		
-		fmt.Printf("Good \"%s\" signature for %s with %s key %s\n", namespace, principalEmail, sig.HashAlgorithm, ssh.FingerprintSHA256(pk))
+		pkType := strings.ToUpper(strings.Split(pk.Type(), "-")[1])
+
+		fmt.Printf("Good \"%s\" signature for %s with %s key %s\n", namespace, principalEmail, pkType, ssh.FingerprintSHA256(pk))
 		os.Exit(0)
 
 	} else if action == "check-novalidate" {
+		os.WriteFile("check-novalidate.txt", []byte(strings.Join(os.Args, "\n")), 0644)
+
+		sig, err := signatureFileToObj(signatureFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}	
+
+		pkType := strings.ToUpper(strings.Split(sig.PublicKey.Type(), "-")[1])
+		fmt.Printf("Good \"%s\" signature with %s key %s\n", namespace, pkType, ssh.FingerprintSHA256(sig.PublicKey))
+		fmt.Println("No principal matched")
 		os.Exit(0)
 
 	} else {

--- a/cmd/ssh-sign/main.go
+++ b/cmd/ssh-sign/main.go
@@ -45,19 +45,19 @@ func main() {
 			following arguments:	
 				-Y sign -n git -f <KEY> /tmp/.git_signing_buffer_file
 
-			The <KEY> is the user.signingkey value from the git config. This will
-			be the UID of the record in the Vault.
-			The /tmp/.git_signing_buffer_file is the file that contains the commit
-			data that is to be signed.
+			The <KEY> is the user.signingkey value from the git config. This 
+			will be the UID of the record in the Vault.
+			The /tmp/.git_signing_buffer_file is the file that contains the 
+			commit data that is to be signed.
 
 			We need to:
 			1. Fetch the private key from the Vault based on the UID.
 			2. Sign the commit.
-			3. Write the signature to a file. The file name should be the same as
-			the commit file but with a .sig extension.
+			3. Write the signature to a file. The file name should be the same 
+			as the commit file but with a .sig extension.
 
-			As long as the program returns a 0 exit code, git will continue with
-			the commit, even if incorrectly signed. git wil not verify the
+			As long as the program returns a 0 exit code, git will continue 
+			with the commit, even if incorrectly signed. git wil not verify the
 			signature at the time of commiting. If the exit code is non-zero,
 			git will abort the commit.
 		*/
@@ -199,11 +199,10 @@ func main() {
 		os.Exit(0)
 
 	} else if action == "check-novalidate" {
-		// Checks the principal passed by git against the public key in the
-		// signature file. If they match, the signature is valid. At this point
-		// of the workflow, git already knows the publis key is not in the 
-		// allowed_signers file, and therefore will not be able to verify the 
-		// signature.
+		// If unable to verify the principal is in the allowed_signers file, 
+		// git hecks the principal passed by git against the public key in the 
+		// signature file. If they match, the signature is valid, but not 
+		// verified.
 		sig, err := verify.ParseSignatureFile(signatureFile)
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/ssh-sign/main.go
+++ b/cmd/ssh-sign/main.go
@@ -36,62 +36,78 @@ func main() {
 	var action string
 	var namespace string
 	var sshUID string
+	var signatureFile string
+	var timestamp string
 
-	flag.StringVar(&action, "Y", "", "Action to perform") // Only 'sign' is currently supported.
-	flag.StringVar(&namespace, "n", "", "Namespace")      // Only 'git' is supported.
+	flag.StringVar(&action, "Y", "", "Action to perform") 
+	flag.StringVar(&namespace, "n", "", "Namespace")      
 	flag.StringVar(&sshUID, "f", "", "SSH Key UID")
+	flag.StringVar(&signatureFile, "s", "", "Signature file for verificaton")
+	flag.StringVar(&timestamp, "Overify-time", "", "TODO")
 	flag.Parse()
 
-	if len(flag.Args()) == 0 {
+	if len(os.Args) == 0 {
 		fmt.Println("This program is not intended to be run directly. It is called by git when signing commits.")
 		os.Exit(1)
 	}
+
+	// Only the 'git' namespace is supported.
 	if namespace != "git" {
 		fmt.Println("Only the 'git' namespace is supported.")
 		os.Exit(1)
 	}
-	if action != "sign" {
-		fmt.Println("Only the 'sign' action is supported.")
-		os.Exit(1)
-	}
 
-	// `flag.Args` returns the non-flag arguments, only. In this case, the 
-	// first and only argument should be the path to the file that contains the 
-	// commit data.
-	commitToSign := flag.Args()[0]
+	if action == "sign" {
+		// `flag.Args` returns the non-flag arguments, only. In this case, the 
+		// first and only argument should be the path to the file that contains 
+		// the commit data.
+		commitToSign := flag.Args()[0]
+		if commitToSign == "" {
+			fmt.Println("No commit file specified.")
+			os.Exit(1)
+		}
+	
+		privateKey, err := vault.FetchPrivateKey(sshUID)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	
+		file, err := os.Open(commitToSign)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	
+		// To ensure that git can read the final signature file, we capture the
+		// file permissions of the commit file to ensure the signature file has the
+		// same permissions.
+		fileinfo, err := os.Stat(commitToSign)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fileMode := fileinfo.Mode()
+	
+		sig, err := sign.SignCommit(privateKey, file)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	
+		if err := os.WriteFile(fmt.Sprintf("%s.sig", commitToSign), sig, fileMode); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		} else {
+			os.Exit(0)
+		}
+	} else if action == "check-novalidate" { 
+		// -Y check-novalidate -n git -s C:\Users\RICKYW~1\AppData\Local\Temp/.git_vtag_tmpudh6g6 -Overify-time=20230920083515
 
-	privateKey, err := vault.FetchPrivateKey(sshUID)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	file, err := os.Open(commitToSign)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	// To ensure that git can read the final signature file, we capture the
-	// file permissions of the commit file to ensure the signature file has the
-	// same permissions.
-	fileinfo, err := os.Stat(commitToSign)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	fileMode := fileinfo.Mode()
-
-	sig, err := sign.SignCommit(privateKey, file)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	if err := os.WriteFile(fmt.Sprintf("%s.sig", commitToSign), sig, fileMode); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
 	} else {
-		os.Exit(0)
+		fmt.Println("Unsupported action. Only 'sign' and 'check-novalidate' are supported")
+		os.Exit(1)
 	}
 }
+
+

--- a/internal/sign/verify.go
+++ b/internal/sign/verify.go
@@ -115,10 +115,6 @@ func FindMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string,
 }
 
 func VerifyFingerprints(principal []byte, pubKey ssh.PublicKey) error {
-
-	fmt.Println(string(principal))
-	fmt.Println(string(pubKey.Marshal()))
-
 	// Parse into wire format
 	pak, _, _, _, err := ssh.ParseAuthorizedKey(principal)
 	if err != nil {

--- a/internal/sign/verify.go
+++ b/internal/sign/verify.go
@@ -1,0 +1,133 @@
+package sign
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"hash"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+
+type Signature struct {
+	signature *ssh.Signature
+	pubKey    ssh.PublicKey
+	hashAlg   string
+}
+
+var supportedHashAlgorithms = map[string]func() hash.Hash{
+	"sha256": sha256.New,
+	"sha512": sha512.New,
+}
+
+func Decode(b []byte) (*Signature, error) {
+	// Borrowed from SigStore
+	pemBlock, _ := pem.Decode(b)
+	if pemBlock == nil {
+		return nil, errors.New("unable to decode pem file")
+	}
+
+	if pemBlock.Type != "SSH SIGNATURE" {
+		return nil, fmt.Errorf("wrong pem block type: %s. Expected SSH-SIGNATURE", pemBlock.Type)
+	}
+
+	// Now we unmarshal it into the Signature block
+	sig := WrappedSig{}
+	if err := ssh.Unmarshal(pemBlock.Bytes, &sig); err != nil {
+		return nil, err
+	}
+
+	if sig.Version != 1 {
+		return nil, fmt.Errorf("unsupported signature version: %d", sig.Version)
+	}
+	if string(sig.MagicHeader[:]) != magicHeader {
+		return nil, fmt.Errorf("invalid magic header: %s", sig.MagicHeader[:])
+	}
+	if sig.Namespace != "git" {
+		return nil, fmt.Errorf("invalid signature namespace: %s", sig.Namespace)
+	}
+	if _, ok := supportedHashAlgorithms[sig.HashAlgorithm]; !ok {
+		return nil, fmt.Errorf("unsupported hash algorithm: %s", sig.HashAlgorithm)
+	}
+
+	// Now we can unpack the Signature and PublicKey blocks
+	sshSig := ssh.Signature{}
+	if err := ssh.Unmarshal([]byte(sig.Signature), &sshSig); err != nil {
+		return nil, err
+	}
+
+	pk, err := ssh.ParsePublicKey([]byte(sig.PublicKey))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Signature{
+		signature: &sshSig,
+		pubKey:    pk,
+		hashAlg:   sig.HashAlgorithm,
+	}, nil
+}
+
+
+func Verify(armoredSignature []byte, key []byte) (bool, error) {
+	decodedSignature, err := Decode(armoredSignature)
+	if err != nil {
+		return false, err
+	}
+
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(key)
+	if err != nil {
+		return false, err
+	}
+
+	if decodedSignature.pubKey == publicKey {
+		fmt.Println("Public keys match")
+		return true, nil
+	} else	{
+		fmt.Println("Public keys do not match")
+		return false, nil
+	}
+
+}
+
+func GetAllowedSigners(f *os.File) ([]string, error) {
+    var publicKeys []string
+    scanner := bufio.NewScanner(f)
+    for scanner.Scan() {
+        line := scanner.Text()
+        fields := strings.Fields(line)
+        for index, field := range fields {
+            if strings.HasPrefix(field, "ssh") {
+				publicKeys = append(publicKeys, field+" "+fields[index+1])
+				break
+            }
+        }
+    }
+    if err := scanner.Err(); err != nil {
+        return nil, err
+    }
+
+    return publicKeys, nil
+}
+
+func FindMatchingPrincipals(allowedSigners []string, signature *Signature) ([]string, error) {
+	var matchingPrincipals []string
+	for _, p := range allowedSigners {
+		// Parse into wire format
+		pak, _, _, _, err := ssh.ParseAuthorizedKey([]byte(p))
+		if err != nil {
+			return nil, err
+		}	
+		if bytes.Equal(signature.pubKey.Marshal(), pak.Marshal()) {
+			matchingPrincipals = append(matchingPrincipals, p)
+		}
+	}
+	return matchingPrincipals, nil
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -33,9 +33,9 @@ var supportedHashAlgorithms = map[string]func() hash.Hash{
 	"sha512": sha512.New,
 }
 
-// Decodes a PEM encoded signature into a Signature struct. If invalid or 
-// unsupported data is found, an error is returned, even if the signature is 
-// valid for other use cases outside of the restrictions of this program. 
+// Decodes a PEM encoded signature into a Signature struct. If invalid or
+// unsupported data is found, an error is returned, even if the signature is
+// valid for other use cases outside of the restrictions of this program.
 func Decode(b []byte) (*Signature, error) {
 	pemBlock, _ := pem.Decode(b)
 	if pemBlock == nil {
@@ -43,7 +43,7 @@ func Decode(b []byte) (*Signature, error) {
 	}
 
 	if pemBlock.Type != "SSH SIGNATURE" {
-		return nil, fmt.Errorf("wrong pem block type: %s. Expected SSH-SIGNATURE", pemBlock.Type)
+		return nil, fmt.Errorf("unsupported block type '%s'", pemBlock.Type)
 	}
 
 	// Unmarshal into the Signature block
@@ -52,51 +52,51 @@ func Decode(b []byte) (*Signature, error) {
 		return nil, err
 	}
 
-	// Validation of the Signature block is done before we can unpack the 
-	// Signature and PublicKey blocks. This ensures that we don't unpack 
+	// Validation of the Signature block is done before we can unpack the
+	// Signature and PublicKey blocks. This ensures that we don't unpack
 	// malicious, invalid, or unsupported data. Instead, we can return an
 	// error before we do any unpacking.
 	if sig.Version != 1 {
 		return nil, fmt.Errorf("unsupported signature version: %d", sig.Version)
 	}
 	if string(sig.MagicHeader[:]) != sign.MagicHeader {
-		return nil, fmt.Errorf("invalid magic header: %s", sig.MagicHeader[:])
+		return nil, fmt.Errorf("invalid magic header: '%s'", sig.MagicHeader[:])
 	}
 	if sig.Namespace != sign.Namespace {
-		return nil, fmt.Errorf("invalid signature namespace: %s", sig.Namespace)
+		return nil, fmt.Errorf("invalid signature namespace: '%s'", sig.Namespace)
 	}
 	if _, ok := supportedHashAlgorithms[sig.HashAlgorithm]; !ok {
-		return nil, fmt.Errorf("unsupported hash algorithm: %s", sig.HashAlgorithm)
+		return nil, fmt.Errorf("unsupported hash algorithm: '%s'", sig.HashAlgorithm)
 	}
 
 	// Now we can unpack the Signature and PublicKey blocks
-	sshSig := ssh.Signature{}
-	if err := ssh.Unmarshal([]byte(sig.Signature), &sshSig); err != nil {
+	signature := ssh.Signature{}
+	if err := ssh.Unmarshal([]byte(sig.Signature), &signature); err != nil {
 		return nil, err
 	}
 
-	pk, err := ssh.ParsePublicKey([]byte(sig.PublicKey))
+	publicKey, err := ssh.ParsePublicKey([]byte(sig.PublicKey))
 	if err != nil {
 		return nil, err
 	}
 
 	return &Signature{
-		Signature:     &sshSig,
-		PublicKey:     pk,
+		Signature:     &signature,
+		PublicKey:     publicKey,
 		HashAlgorithm: sig.HashAlgorithm,
 	}, nil
 }
 
 // Finds matching principals for the given signature.
-func FindMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string, error) {
+func GetMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string, error) {
 	var matchingPrincipals []string
 	for _, p := range as {
 		// Parse into SSH wire format
-		pak, _, _, _, err := ssh.ParseAuthorizedKey([]byte(p.PublicKey))
+		authorizedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(p.PublicKey))
 		if err != nil {
 			return nil, err
 		}
-		if bytes.Equal(signature.PublicKey.Marshal(), pak.Marshal()) {
+		if bytes.Equal(signature.PublicKey.Marshal(), authorizedKey.Marshal()) {
 			matchingPrincipals = append(matchingPrincipals, p.PublicKey)
 		}
 	}
@@ -105,7 +105,7 @@ func FindMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string,
 
 // Parse a given file and returns a slice of AllowedSigners.
 // This only supports one email address per public key, currently.
-func GetAllowedSigners(f string)([]AllowedSigner, error) {
+func GetAllowedSigners(f string) ([]AllowedSigner, error) {
 	asf, err := os.Open(f)
 	if err != nil {
 		fmt.Println(err)
@@ -118,10 +118,9 @@ func GetAllowedSigners(f string)([]AllowedSigner, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		fields := strings.Fields(line)
-
 		as := AllowedSigner{
-			Email: fields[0],
-			PublicKey: fields[1]+ " " + fields[2],
+			Email:     fields[0],
+			PublicKey: fields[1] + " " + fields[2],
 		}
 		allowedSigners = append(allowedSigners, as)
 	}
@@ -153,16 +152,16 @@ func ParseSignatureFile(filepath string) (*Signature, error) {
 	return sig, nil
 }
 
-// Compares the fingerprint of the principal with the public key in the 
+// Compares the fingerprint of the principal with the public key in the
 // signature.
 func VerifyFingerprints(principal []byte, pubKey ssh.PublicKey) error {
 	// Parse into wire format
-	pak, _, _, _, err := ssh.ParseAuthorizedKey(principal)
+	key, _, _, _, err := ssh.ParseAuthorizedKey(principal)
 	if err != nil {
 		return err
 	}
 
-	principalHash := []byte(ssh.FingerprintSHA256(pak))
+	principalHash := []byte(ssh.FingerprintSHA256(key))
 	pubKeyHash := []byte(ssh.FingerprintSHA256(pubKey))
 
 	if bytes.Equal(principalHash, pubKeyHash) {

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -35,7 +35,7 @@ var supportedHashAlgorithms = map[string]func() hash.Hash{
 
 // Decodes a PEM encoded signature into a Signature struct. If invalid or 
 // unsupported data is found, an error is returned, even if the signature is 
-// valid for other use cases ourside of the restrictions of this program. 
+// valid for other use cases outside of the restrictions of this program. 
 func Decode(b []byte) (*Signature, error) {
 	pemBlock, _ := pem.Decode(b)
 	if pemBlock == nil {
@@ -91,7 +91,7 @@ func Decode(b []byte) (*Signature, error) {
 func FindMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string, error) {
 	var matchingPrincipals []string
 	for _, p := range as {
-		// Parse into wire format
+		// Parse into SSH wire format
 		pak, _, _, _, err := ssh.ParseAuthorizedKey([]byte(p.PublicKey))
 		if err != nil {
 			return nil, err
@@ -104,6 +104,7 @@ func FindMatchingPrincipals(as []AllowedSigner, signature *Signature) ([]string,
 }
 
 // Parse a given file and returns a slice of AllowedSigners.
+// This only supports one email address per public key, currently.
 func GetAllowedSigners(f string)([]AllowedSigner, error) {
 	asf, err := os.Open(f)
 	if err != nil {
@@ -131,9 +132,9 @@ func GetAllowedSigners(f string)([]AllowedSigner, error) {
 	return allowedSigners, nil
 }
 
-// Parse a given file and returns a Signature struct.
-func ParseSignatureFile(signatureFile string) (*Signature, error) {
-	signature, err := os.Open(signatureFile)
+// Parse a given signature from a file and returns a Signature struct.
+func ParseSignatureFile(filepath string) (*Signature, error) {
+	signature, err := os.Open(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -69,17 +69,16 @@ MQUjv26NIZPFqtAAAADHRlc3RAZXhhbXBsZQECAwQFBg==
 `
 
 	rsaPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDD8QxHgdYL7YQcy7HMsYn/JfFAfwJWNq5nCkkgfko7bA+NQeQcNzLhHIoz5TfCHux5Kb+H+mbb4mYZDY0eT2zgy5QbZkJpggeFw6mdT2n2Dgvof/gJULsDBh6ZbktRTlwkQXDg0OJT/W2CCo5J+5DoXaVczw68OmTd72j08/p56BsbXJK7RUpUK+m3gmhfmMQl7M5QCVVEe22PpXu7AMV6lmqym6cqcqMrman2+szcAvhqO+TNZBKI3zI8RXZHIHFSSQMlXMBqShm8IkynmRVy8kFy9K7tkjNoGlfiD/yi73ChaGZLhx2d8/cFm5FgRzEbA45fOVC0DMeNKpRoFejYZHrekwisAcIoZ2G2buxa6hzPxAC24cZ5F/eEeVmn+Lj8tWSPRR7p7AEMWnNqt0gNhY6wv+iAwkScvXRSBKwvnOQIXKGz2iYuRyhjuAkvrJDfpOw58bNILaTRzeRQAbR5UnsURN4nIKOg5/ioPkR85c4Dr31/DmAOTttdw4Sne0E="
-
 )
 
 var (
 	allowedSigners = []AllowedSigner{
 		{
-			Email: "test@example.com",
+			Email:     "test@example.com",
 			PublicKey: ed25519PublicKey,
 		},
 		{
-			Email: "test@example.com",
+			Email:     "test@example.com",
 			PublicKey: rsaPublicKey,
 		},
 	}
@@ -90,60 +89,59 @@ func TestFindMatchingPrincipals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse test principal: %v", err)
 	}
-	
+
 	sig := &Signature{
-        PublicKey: principal,
-    }
+		PublicKey: principal,
+	}
 
-    // Find matching principals
-    matchingPrincipals, err := FindMatchingPrincipals(allowedSigners, sig)
-    if err != nil {
-        t.Fatalf("FindMatchingPrincipals returned an error: %v", err)
-    }
+	// Find matching principals
+	matchingPrincipals, err := FindMatchingPrincipals(allowedSigners, sig)
+	if err != nil {
+		t.Fatalf("FindMatchingPrincipals returned an error: %v", err)
+	}
 
-    // Check that the correct principals were found
-    expectedPrincipals := []string{allowedSigners[0].PublicKey}
-    if !reflect.DeepEqual(matchingPrincipals, expectedPrincipals) {
-        t.Errorf("FindMatchingPrincipals returned %v, expected %v", matchingPrincipals, expectedPrincipals)
-    }
+	// Check that the correct principals were found
+	expectedPrincipals := []string{allowedSigners[0].PublicKey}
+	if !reflect.DeepEqual(matchingPrincipals, expectedPrincipals) {
+		t.Errorf("FindMatchingPrincipals returned %v, expected %v", matchingPrincipals, expectedPrincipals)
+	}
 }
 
 func TestGetAllowedSigners(t *testing.T) {
-    // Create a test file
-    testFile := "testfile.txt"
-    f, err := os.Create(testFile)
-    if err != nil {
-		t.Fatalf("Failed to create test file: %v", err)
-    }
-    fmt.Fprintln(f, allowedSigners[0].Email, allowedSigners[0].PublicKey)
-    fmt.Fprintln(f, allowedSigners[1].Email, allowedSigners[1].PublicKey)
-	defer f.Close()
+	// Create a test file
+	testFile := "testfile.txt"
+	f, err := os.Create(testFile)
 	defer os.Remove(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	defer f.Close()
+	fmt.Fprintln(f, allowedSigners[0].Email, allowedSigners[0].PublicKey)
+	fmt.Fprintln(f, allowedSigners[1].Email, allowedSigners[1].PublicKey)
 
-    // Get the AllowedSigners from the test file
-    as, err := GetAllowedSigners(testFile)
-    if err != nil {
-        t.Fatalf("GetAllowedSigners returned an error: %v", err)
-    }
+	// Get the AllowedSigners from the test file
+	as, err := GetAllowedSigners(testFile)
+	if err != nil {
+		t.Fatalf("GetAllowedSigners returned an error: %v", err)
+	}
 
-    if !reflect.DeepEqual(as, allowedSigners) {
-        t.Errorf("GetAllowedSigners returned %v, expected %v", as, allowedSigners)
-    }
+	if !reflect.DeepEqual(as, allowedSigners) {
+		t.Errorf("GetAllowedSigners returned %v, expected %v", as, allowedSigners)
+	}
 }
 
 func TestVerifyFingerprints(t *testing.T) {
-    // Create a test principal and public key
-    principal := []byte(ed25519PublicKey)
-    pubKey, _, _, _, err := ssh.ParseAuthorizedKey(principal)
-    if err != nil {
-        t.Fatalf("Failed to parse test principal: %v", err)
-    }
+	// Create a test principal and public key
+	principal := []byte(ed25519PublicKey)
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(principal)
+	if err != nil {
+		t.Fatalf("Failed to parse test principal: %v", err)
+	}
 
-    if err := VerifyFingerprints(principal, pubKey); err != nil {
-        t.Errorf("VerifyFingerprints returned an error: %v", err)
-    }
+	if err := VerifyFingerprints(principal, pubKey); err != nil {
+		t.Errorf("VerifyFingerprints returned an error: %v", err)
+	}
 }
-
 
 func TestVerifySignature(t *testing.T) {
 	data := []byte("Hello, git-ssh-sign!")
@@ -202,7 +200,6 @@ func TestVerifySignature(t *testing.T) {
 
 }
 
-
 func TestValidDecode(t *testing.T) {
 	data := []byte("Hello, decode function!")
 
@@ -253,12 +250,12 @@ func TestValidDecode(t *testing.T) {
 func TestInvalidDecode(t *testing.T) {
 	dataFile := "invalid-decode.txt"
 	f, err := os.Create(dataFile)
+	defer os.Remove(dataFile)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
-	fmt.Fprintln(f, "Hello, decode function!")
 	defer f.Close()
-	defer os.Remove(dataFile)
+	fmt.Fprintln(f, "Hello, decode function!")
 
 	for _, tt := range []struct {
 		name string
@@ -295,91 +292,53 @@ func TestInvalidDecode(t *testing.T) {
 			}
 
 			// Wrap the signature in a MessageWrapper with an invalid namespace
-			swn := sign.WrappedSig{
-				Version:       1,
-				PublicKey:     string(tt.pub),
-				Namespace:     "file",
-				HashAlgorithm: sign.DefaultHashAlgorithm,
-				Signature:     string(ssh.Marshal(sig)),
-			}
-		
-			copy(swn.MagicHeader[:], sign.MagicHeader)
-		
-			swnPEM := pem.EncodeToMemory(&pem.Block{
-				Type:  "SSH SIGNATURE",
-				Bytes: ssh.Marshal(sig),
-			})
+			swn := CreateInvalidArmor(1, string(tt.pub), "INVALID", sign.DefaultHashAlgorithm, sig, sign.MagicHeader)
 
-			// Check that Decode returns an error when given an invalid 
-			// signature
-			_, err = Decode(swnPEM)
+			_, err = Decode(swn)
 			if err == nil {
 				t.Fatalf("Decode returned no error, expected error")
 			}
 
 			// Wrap the signature in a MessageWrapper with an invalid hash
-			swh := sign.WrappedSig{
-				Version:       1,
-				PublicKey:     string(tt.pub),
-				Namespace:     sign.Namespace,
-				HashAlgorithm: "invalid",
-				Signature:     string(ssh.Marshal(sig)),
-			}
-
-			copy(swh.MagicHeader[:], sign.MagicHeader)
-		
-			swhPEM := pem.EncodeToMemory(&pem.Block{
-				Type:  "SSH SIGNATURE",
-				Bytes: ssh.Marshal(sig),
-			})
-			_, err = Decode(swhPEM)
+			swh := CreateInvalidArmor(1, string(tt.pub), sign.Namespace, "INVALID", sig, sign.MagicHeader)
+			_, err = Decode(swh)
 			if err == nil {
 				t.Fatalf("Decode returned no error, expected error")
 			}
 
-			// Wrap the signature in a MessageWrapper with an invalid magic 
+			// Wrap the signature in a MessageWrapper with an invalid magic
 			// header
-			swmh := sign.WrappedSig{
-				Version:       1,
-				PublicKey:     string(tt.pub),
-				Namespace:     sign.Namespace,
-				HashAlgorithm: sign.DefaultHashAlgorithm,
-				Signature:     string(ssh.Marshal(sig)),
-			}
-
-			copy(swmh.MagicHeader[:], "INVALID")
-		
-			swmhPEM := pem.EncodeToMemory(&pem.Block{
-				Type:  "SSH SIGNATURE",
-				Bytes: ssh.Marshal(sig),
-			})
-			_, err = Decode(swmhPEM)
+			swmh := CreateInvalidArmor(1, string(tt.pub), sign.Namespace, sign.DefaultHashAlgorithm, sig, "INVALID")
+			_, err = Decode(swmh)
 			if err == nil {
 				t.Fatalf("Decode returned no error, expected error")
 			}
 
 			// Wrap the signature in a MessageWrapper with an invalid version
-			swv := sign.WrappedSig{
-				Version:       1000,
-				PublicKey:     string(tt.pub),
-				Namespace:     sign.Namespace,
-				HashAlgorithm: sign.DefaultHashAlgorithm,
-				Signature:     string(ssh.Marshal(sig)),
-			}
-
-			copy(swv.MagicHeader[:], sign.MagicHeader)
-		
-			swvPEM := pem.EncodeToMemory(&pem.Block{
-				Type:  "SSH SIGNATURE",
-				Bytes: ssh.Marshal(sig),
-			})
-			_, err = Decode(swvPEM)
+			swv := CreateInvalidArmor(1000, string(tt.pub), sign.Namespace, sign.DefaultHashAlgorithm, sig, sign.MagicHeader)
+			_, err = Decode(swv)
 			if err == nil {
 				t.Fatalf("Decode returned no error, expected error")
 			}
-
-
 		})
 	}
 
+}
+
+func CreateInvalidArmor(v uint32, pk string, ns string, ha string, sig *ssh.Signature, mh string) []byte {
+	sw := sign.WrappedSig{
+		Version:       v,
+		PublicKey:     pk,
+		Namespace:     ns,
+		HashAlgorithm: ha,
+		Signature:     string(ssh.Marshal(sig)),
+	}
+	copy(sw.MagicHeader[:], mh)
+
+	enc := pem.EncodeToMemory(&pem.Block{
+		Type:  "SSH SIGNATURE",
+		Bytes: ssh.Marshal(sw),
+	})
+
+	return enc
 }

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -294,7 +294,7 @@ func TestInvalidDecode(t *testing.T) {
 			}
 
 			// Wrap the signature in a MessageWrapper with an invalid namespace
-			// and test is fails
+			// and test it fails
 			swn := CreateInvalidArmor(1, string(tt.pub), "INVALID", sign.DefaultHashAlgorithm, sig, sign.MagicHeader)
 			_, err = Decode(swn)
 			if err == nil {
@@ -302,7 +302,7 @@ func TestInvalidDecode(t *testing.T) {
 			}
 
 			// Wrap the signature in a MessageWrapper with an invalid hash and 
-			// test is fails
+			// test it fails
 			swh := CreateInvalidArmor(1, string(tt.pub), sign.Namespace, "INVALID", sig, sign.MagicHeader)
 			_, err = Decode(swh)
 			if err == nil {

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -2,6 +2,10 @@ package verify
 
 import (
 	"bytes"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/Keeper-Security/git-ssh-sign/internal/sign"
@@ -20,7 +24,7 @@ lenrm3hZ4B7DdcB/4/H+AAAAEHRlc3RAZXhhbXBsZS5jb20BAgMEBQ==
 -----END OPENSSH PRIVATE KEY-----		
 `
 
-	ed25519PublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEQvSrBv28KLAjYO7pD91prhlenrm3hZ4B7DdcB/4/H+ test@example.com"
+	ed25519PublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEQvSrBv28KLAjYO7pD91prhlenrm3hZ4B7DdcB/4/H+"
 
 	// The following value was generated using the following command:
 	// 		ssh-keygen -C test@example -f test_key
@@ -64,9 +68,81 @@ MQUjv26NIZPFqtAAAADHRlc3RAZXhhbXBsZQECAwQFBg==
 -----END OPENSSH PRIVATE KEY-----
 `
 
-	rsaPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDD8QxHgdYL7YQcy7HMsYn/JfFAfwJWNq5nCkkgfko7bA+NQeQcNzLhHIoz5TfCHux5Kb+H+mbb4mYZDY0eT2zgy5QbZkJpggeFw6mdT2n2Dgvof/gJULsDBh6ZbktRTlwkQXDg0OJT/W2CCo5J+5DoXaVczw68OmTd72j08/p56BsbXJK7RUpUK+m3gmhfmMQl7M5QCVVEe22PpXu7AMV6lmqym6cqcqMrman2+szcAvhqO+TNZBKI3zI8RXZHIHFSSQMlXMBqShm8IkynmRVy8kFy9K7tkjNoGlfiD/yi73ChaGZLhx2d8/cFm5FgRzEbA45fOVC0DMeNKpRoFejYZHrekwisAcIoZ2G2buxa6hzPxAC24cZ5F/eEeVmn+Lj8tWSPRR7p7AEMWnNqt0gNhY6wv+iAwkScvXRSBKwvnOQIXKGz2iYuRyhjuAkvrJDfpOw58bNILaTRzeRQAbR5UnsURN4nIKOg5/ioPkR85c4Dr31/DmAOTttdw4Sne0E= test@example"
+	rsaPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDD8QxHgdYL7YQcy7HMsYn/JfFAfwJWNq5nCkkgfko7bA+NQeQcNzLhHIoz5TfCHux5Kb+H+mbb4mYZDY0eT2zgy5QbZkJpggeFw6mdT2n2Dgvof/gJULsDBh6ZbktRTlwkQXDg0OJT/W2CCo5J+5DoXaVczw68OmTd72j08/p56BsbXJK7RUpUK+m3gmhfmMQl7M5QCVVEe22PpXu7AMV6lmqym6cqcqMrman2+szcAvhqO+TNZBKI3zI8RXZHIHFSSQMlXMBqShm8IkynmRVy8kFy9K7tkjNoGlfiD/yi73ChaGZLhx2d8/cFm5FgRzEbA45fOVC0DMeNKpRoFejYZHrekwisAcIoZ2G2buxa6hzPxAC24cZ5F/eEeVmn+Lj8tWSPRR7p7AEMWnNqt0gNhY6wv+iAwkScvXRSBKwvnOQIXKGz2iYuRyhjuAkvrJDfpOw58bNILaTRzeRQAbR5UnsURN4nIKOg5/ioPkR85c4Dr31/DmAOTttdw4Sne0E="
 
 )
+
+var (
+	allowedSigners = []AllowedSigner{
+		{
+			Email: "test@example.com",
+			PublicKey: ed25519PublicKey,
+		},
+		{
+			Email: "test@example.com",
+			PublicKey: rsaPublicKey,
+		},
+	}
+)
+
+func TestFindMatchingPrincipals(t *testing.T) {
+	principal, _, _, _, err := ssh.ParseAuthorizedKey([]byte(allowedSigners[0].PublicKey))
+	if err != nil {
+		t.Fatalf("Failed to parse test principal: %v", err)
+	}
+	
+	sig := &Signature{
+        PublicKey: principal,
+    }
+
+    // Find matching principals
+    matchingPrincipals, err := FindMatchingPrincipals(allowedSigners, sig)
+    if err != nil {
+        t.Fatalf("FindMatchingPrincipals returned an error: %v", err)
+    }
+
+    // Check that the correct principals were found
+    expectedPrincipals := []string{allowedSigners[0].PublicKey}
+    if !reflect.DeepEqual(matchingPrincipals, expectedPrincipals) {
+        t.Errorf("FindMatchingPrincipals returned %v, expected %v", matchingPrincipals, expectedPrincipals)
+    }
+}
+
+func TestGetAllowedSigners(t *testing.T) {
+    // Create a test file
+    testFile := "testfile.txt"
+    f, err := os.Create(testFile)
+    if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+    }
+    fmt.Fprintln(f, allowedSigners[0].Email, allowedSigners[0].PublicKey)
+    fmt.Fprintln(f, allowedSigners[1].Email, allowedSigners[1].PublicKey)
+	defer f.Close()
+	defer os.Remove(testFile)
+
+    // Get the AllowedSigners from the test file
+    as, err := GetAllowedSigners(testFile)
+    if err != nil {
+        t.Fatalf("GetAllowedSigners returned an error: %v", err)
+    }
+
+    if !reflect.DeepEqual(as, allowedSigners) {
+        t.Errorf("GetAllowedSigners returned %v, expected %v", as, allowedSigners)
+    }
+}
+
+func TestVerifyFingerprints(t *testing.T) {
+    // Create a test principal and public key
+    principal := []byte(ed25519PublicKey)
+    pubKey, _, _, _, err := ssh.ParseAuthorizedKey(principal)
+    if err != nil {
+        t.Fatalf("Failed to parse test principal: %v", err)
+    }
+
+    if err := VerifyFingerprints(principal, pubKey); err != nil {
+        t.Errorf("VerifyFingerprints returned an error: %v", err)
+    }
+}
 
 
 func TestVerifySignature(t *testing.T) {
@@ -121,6 +197,188 @@ func TestVerifySignature(t *testing.T) {
 			if err := VerifyFingerprints([]byte(otherSSHPublicKey), decodedSignature.PublicKey); err == nil {
 				t.Error("expected error!")
 			}
+		})
+	}
+
+}
+
+
+func TestValidDecode(t *testing.T) {
+	data := []byte("Hello, decode function!")
+
+	for _, tt := range []struct {
+		name string
+		pub  string
+		priv string
+	}{
+		{
+			name: "rsa",
+			pub:  rsaPublicKey,
+			priv: rsaPrivateKey,
+		},
+		{
+			name: "ed25519",
+			pub:  ed25519PublicKey,
+			priv: ed25519PrivateKey,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+
+			s, err := ssh.ParsePrivateKey([]byte(tt.priv))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			as, ok := s.(ssh.AlgorithmSigner)
+			if !ok {
+				t.Fatal(err)
+			}
+
+			signature, err := sign.NewSignature(as, bytes.NewReader(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Check that Decode returns no error when given a valid signature
+			_, err = Decode(sign.Armor(signature, s.PublicKey()))
+			if err != nil {
+				t.Fatalf("Decode returned an error: %v", err)
+			}
+		})
+	}
+
+}
+
+func TestInvalidDecode(t *testing.T) {
+	dataFile := "invalid-decode.txt"
+	f, err := os.Create(dataFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	fmt.Fprintln(f, "Hello, decode function!")
+	defer f.Close()
+	defer os.Remove(dataFile)
+
+	for _, tt := range []struct {
+		name string
+		pub  string
+		priv string
+	}{
+		{
+			name: "rsa",
+			pub:  rsaPublicKey,
+			priv: rsaPrivateKey,
+		},
+		{
+			name: "ed25519",
+			pub:  ed25519PublicKey,
+			priv: ed25519PrivateKey,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+
+			s, err := ssh.ParsePrivateKey([]byte(tt.priv))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			as, ok := s.(ssh.AlgorithmSigner)
+			if !ok {
+				t.Fatal(err)
+			}
+
+			sig, err := sign.NewSignature(as, f)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Wrap the signature in a MessageWrapper with an invalid namespace
+			swn := sign.WrappedSig{
+				Version:       1,
+				PublicKey:     string(tt.pub),
+				Namespace:     "file",
+				HashAlgorithm: sign.DefaultHashAlgorithm,
+				Signature:     string(ssh.Marshal(sig)),
+			}
+		
+			copy(swn.MagicHeader[:], sign.MagicHeader)
+		
+			swnPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "SSH SIGNATURE",
+				Bytes: ssh.Marshal(sig),
+			})
+
+			// Check that Decode returns an error when given an invalid 
+			// signature
+			_, err = Decode(swnPEM)
+			if err == nil {
+				t.Fatalf("Decode returned no error, expected error")
+			}
+
+			// Wrap the signature in a MessageWrapper with an invalid hash
+			swh := sign.WrappedSig{
+				Version:       1,
+				PublicKey:     string(tt.pub),
+				Namespace:     sign.Namespace,
+				HashAlgorithm: "invalid",
+				Signature:     string(ssh.Marshal(sig)),
+			}
+
+			copy(swh.MagicHeader[:], sign.MagicHeader)
+		
+			swhPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "SSH SIGNATURE",
+				Bytes: ssh.Marshal(sig),
+			})
+			_, err = Decode(swhPEM)
+			if err == nil {
+				t.Fatalf("Decode returned no error, expected error")
+			}
+
+			// Wrap the signature in a MessageWrapper with an invalid magic 
+			// header
+			swmh := sign.WrappedSig{
+				Version:       1,
+				PublicKey:     string(tt.pub),
+				Namespace:     sign.Namespace,
+				HashAlgorithm: sign.DefaultHashAlgorithm,
+				Signature:     string(ssh.Marshal(sig)),
+			}
+
+			copy(swmh.MagicHeader[:], "INVALID")
+		
+			swmhPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "SSH SIGNATURE",
+				Bytes: ssh.Marshal(sig),
+			})
+			_, err = Decode(swmhPEM)
+			if err == nil {
+				t.Fatalf("Decode returned no error, expected error")
+			}
+
+			// Wrap the signature in a MessageWrapper with an invalid version
+			swv := sign.WrappedSig{
+				Version:       1000,
+				PublicKey:     string(tt.pub),
+				Namespace:     sign.Namespace,
+				HashAlgorithm: sign.DefaultHashAlgorithm,
+				Signature:     string(ssh.Marshal(sig)),
+			}
+
+			copy(swv.MagicHeader[:], sign.MagicHeader)
+		
+			swvPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "SSH SIGNATURE",
+				Bytes: ssh.Marshal(sig),
+			})
+			_, err = Decode(swvPEM)
+			if err == nil {
+				t.Fatalf("Decode returned no error, expected error")
+			}
+
+
 		})
 	}
 

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -21,7 +21,7 @@ QyNTUxOQAAACBEL0qwb9vCiwI2Du6Q/daa4ZXp65t4WeAew3XAf+Px/gAAAJjrEknt6xJJ
 7QAAAAtzc2gtZWQyNTUxOQAAACBEL0qwb9vCiwI2Du6Q/daa4ZXp65t4WeAew3XAf+Px/g
 AAAECc4rBgLCDFFGGM1TOtV5VpkGTERsYw/237NqOB/AtCOEQvSrBv28KLAjYO7pD91prh
 lenrm3hZ4B7DdcB/4/H+AAAAEHRlc3RAZXhhbXBsZS5jb20BAgMEBQ==
------END OPENSSH PRIVATE KEY-----		
+-----END OPENSSH PRIVATE KEY-----
 `
 
 	ed25519PublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEQvSrBv28KLAjYO7pD91prhlenrm3hZ4B7DdcB/4/H+"
@@ -84,7 +84,7 @@ var (
 	}
 )
 
-func TestFindMatchingPrincipals(t *testing.T) {
+func TestGetMatchingPrincipals(t *testing.T) {
 	principal, _, _, _, err := ssh.ParseAuthorizedKey([]byte(allowedSigners[0].PublicKey))
 	if err != nil {
 		t.Fatalf("Failed to parse test principal: %v", err)
@@ -95,15 +95,15 @@ func TestFindMatchingPrincipals(t *testing.T) {
 	}
 
 	// Find matching principals
-	matchingPrincipals, err := FindMatchingPrincipals(allowedSigners, sig)
+	matchingPrincipals, err := GetMatchingPrincipals(allowedSigners, sig)
 	if err != nil {
-		t.Fatalf("FindMatchingPrincipals returned an error: %v", err)
+		t.Fatalf("GetMatchingPrincipals returned an error: %v", err)
 	}
 
 	// Check that the correct principals were found
 	expectedPrincipals := []string{allowedSigners[0].PublicKey}
 	if !reflect.DeepEqual(matchingPrincipals, expectedPrincipals) {
-		t.Errorf("FindMatchingPrincipals returned %v, expected %v", matchingPrincipals, expectedPrincipals)
+		t.Errorf("GetMatchingPrincipals returned %v, expected %v", matchingPrincipals, expectedPrincipals)
 	}
 }
 
@@ -301,7 +301,7 @@ func TestInvalidDecode(t *testing.T) {
 				t.Fatalf("Decode returned no error, expected error")
 			}
 
-			// Wrap the signature in a MessageWrapper with an invalid hash and 
+			// Wrap the signature in a MessageWrapper with an invalid hash and
 			// test it fails
 			swh := CreateInvalidArmor(1, string(tt.pub), sign.Namespace, "INVALID", sig, sign.MagicHeader)
 			_, err = Decode(swh)


### PR DESCRIPTION
This addresses #25.

This feature will allow `git` to verify all commit signatures on any given repo if they have been signed with SSH keys. 

In order for this feature to be considered complete:

- [X] Add action: `find-principals`. Checks to see if a principal is in the `allowed_signers` file.
- [X] Add action: `verify`. Verifies that a signature was signed with an authorized signing key.
- [X] Add action: `check-novalidate`. Checks that a principal was used to sign the commit but does not appear in the `allowed_signers` file. 
- [x] Update documentation (README.md)