### PR TITLE
Fixes release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}"
+            --repo "${{ github.repository }}" \
             --generate-notes
 
       - name: Upload artifacts


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

GitHub action fails at the creation of the release step, due to missing `/` in the multi-line command. 

## What is the new behavior?

Creating the GitHub release should now be successful.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

**If yes, please describe...**

## Other relevant information

N/A